### PR TITLE
Show subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::SubscriptionsController < ApplicationController
     def index
-        render json: SubscriptionSerializer.new(Subscription.all, { params: { include_customers: false } }), status: :ok
+        render json: SubscriptionSerializer.new(Subscription.all), status: :ok
     end
 
     def show

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::SubscriptionsController < ApplicationController
     def index
-        render json: SubscriptionSerializer.new(Subscription.all), status: :ok
+        render json: SubscriptionSerializer.new(Subscription.all, { params: { include_customers: false } }), status: :ok
+    end
+
+    def show
+        subscription = Subscription.find(params[:id])
+        render json: SubscriptionSerializer.new(subscription, { params: { include_customers: true } }), status: :ok
     end
 end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -2,7 +2,7 @@ class SubscriptionSerializer
   include JSONAPI::Serializer
   attributes :name, :price, :description, :users_subscribed
 
-  attribute :customers, if: Proc.new { |record, params| params[:include_customers] } do |subscription|
+  attribute :customers, if: Proc.new { |subscription, params| params[:include_customers] == true } do |subscription|
     subscription.subscription_customers
       .includes(:customer)
       .where(subscription_customers: { status: [true, false] })

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,4 +1,18 @@
 class SubscriptionSerializer
   include JSONAPI::Serializer
   attributes :name, :price, :description, :users_subscribed
+
+  attribute :customers, if: Proc.new { |record, params| params[:include_customers] } do |subscription|
+    subscription.subscription_customers
+      .includes(:customer)
+      .where(subscription_customers: { status: [true, false] })
+      .map do |subscription_customer|
+        customer = subscription_customer.customer
+        {
+          name: "#{customer.first_name} #{customer.last_name}",
+          email: customer.email,
+          status: subscription_customer.status
+        }
+      end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
         namespace :v1 do
             resources :customers, only: :index
             resources :teas, only: :index
-            resources :subscriptions, only: :index
+            resources :subscriptions, only: [:index, :show]
         end
     end
 end

--- a/spec/requests/customer_request_spec.rb
+++ b/spec/requests/customer_request_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Customer Controller', type: :request do
     before :each do
-        customers = FactoryBot.create_list(:customer, 5)
-        subscriptions = FactoryBot.create_list(:subscription, 3)
-        active_subscription = subscriptions.sample
-        FactoryBot.create(:subscription_customer, customer: customers.first, subscription: active_subscription, status: true)
+        @customers = FactoryBot.create_list(:customer, 5)
+        @subscriptions = FactoryBot.create_list(:subscription, 3)
+        FactoryBot.create(:subscription_customer, customer: @customers.first, subscription: @subscriptions.first, status: true)
+        FactoryBot.create(:subscription_customer, customer: @customers.first, subscription: @subscriptions.first, status: true)
     end
 
     describe 'GET /api/v1/customers' do

--- a/spec/requests/subscription_request_spec.rb
+++ b/spec/requests/subscription_request_spec.rb
@@ -2,21 +2,45 @@ require 'rails_helper'
 
 RSpec.describe 'Subscription Controller', type: :request do
     before :each do
-        subscriptions = FactoryBot.create_list(:subscription, 5)
+        @subscriptions = FactoryBot.create_list(:subscription, 5)
+        @customers = FactoryBot.create_list(:customer, 5)
+        FactoryBot.create(:subscription_customer, customer: @customers.first, subscription: @subscriptions.first, status: true)
+        FactoryBot.create(:subscription_customer, customer: @customers.last, subscription: @subscriptions.first, status: false)
     end
 
-    describe 'GET /api/v1/teas' do
-        it 'returns all teas and their data.' do
-            get api_v1_subscriptions_path
+    describe 'GET /api/v1/subscriptions/:id' do
+        it 'returns all subscriptions and their data, including an additional customers attribute with name, email, and status.' do
+            get api_v1_subscription_path(@subscriptions.first.id)
             expect(response).to be_successful
             expect(response.status).to eq(200)
             json = JSON.parse(response.body, symbolize_names: true)
-            expect(json[:data]).to be_a Array
-            expect(json[:data].count).to eq(5)
-            expect(json[:data].first[:attributes]).to include(:name)
-            expect(json[:data].first[:attributes]).to include(:price)
-            expect(json[:data].first[:attributes]).to include(:description)
-            expect(json[:data].first[:attributes]).to include(:users_subscribed)
+            expect(json[:data]).to be_a Hash
+            expect(json.count).to eq(1)
+            expect(json[:data][:attributes]).to include(:name)
+            expect(json[:data][:attributes]).to include(:price)
+            expect(json[:data][:attributes]).to include(:description)
+            expect(json[:data][:attributes]).to include(:users_subscribed)
+            expect(json[:data][:attributes]).to include(:customers)
+            expect(json[:data][:attributes][:customers].count).to eq(2)
+            expect(json[:data][:attributes][:customers].first).to include(:name)
+            expect(json[:data][:attributes][:customers].first).to include(:email)
+            expect(json[:data][:attributes][:customers].first).to include(:status)
+            expect(json[:data][:attributes][:customers].last).to include(:name)
+            expect(json[:data][:attributes][:customers].last).to include(:email)
+            expect(json[:data][:attributes][:customers].last).to include(:status)
+            expect(json[:data][:attributes][:customers].first[:email]).to eq(@customers.first.email)
+            expect(json[:data][:attributes][:customers].last[:email]).to eq(@customers.last.email)
+            
+        end
+
+        it 'returns an empty customers array if no customers are (or have ever been) subscribed.' do
+            get api_v1_subscription_path(@subscriptions.last.id)
+            expect(response).to be_successful
+            expect(response.status).to eq(200)
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:data]).to be_a Hash
+            expect(json.count).to eq(1)
+            expect(json[:data][:attributes][:customers].count).to eq(0)
         end
     end
 end

--- a/spec/requests/subscription_request_spec.rb
+++ b/spec/requests/subscription_request_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe 'Subscription Controller', type: :request do
         FactoryBot.create(:subscription_customer, customer: @customers.last, subscription: @subscriptions.first, status: false)
     end
 
+    describe 'GET /api/v1/teas' do
+        it 'returns all teas and their data.' do
+            get api_v1_subscriptions_path
+            expect(response).to be_successful
+            expect(response.status).to eq(200)
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:data]).to be_a Array
+            expect(json[:data].count).to eq(5)
+            expect(json[:data].first[:attributes]).to include(:name)
+            expect(json[:data].first[:attributes]).to include(:price)
+            expect(json[:data].first[:attributes]).to include(:description)
+            expect(json[:data].first[:attributes]).to include(:users_subscribed)
+        end
+    end
+
     describe 'GET /api/v1/subscriptions/:id' do
         it 'returns all subscriptions and their data, including an additional customers attribute with name, email, and status.' do
             get api_v1_subscription_path(@subscriptions.first.id)


### PR DESCRIPTION
### Type of change
- [x] New feature
- [ ] Bug Fix
- [x] New tests

### Check the correct boxes
- [x] This code broke nothing
- [ ] This code broke some stuff
- [ ] This code broke everything

### Implements/Fixes:
- Added SHOW route for Subscriptions.
- Added a include_customers param to display customers attribute only SHOW method using a Proc in the serializer.
  - Customers attribute is an array of all the customers that are currently  (or  used to be) signed up for that subscription.
- Wrote test for SHOW one subscription (test is passing).
  - Verified Customers attribute is displayed.
  - Verified it is displayed and empty, if no customers are, or have ever been, signed up for that subscription.

### Testing Changes:
- [x] I have fully tested my code
- [x] All tests are passing
- [ ] Some tests are failing
- [ ] All tests are failing
- [ ] No previous tests have been changed
- [ ] Some previous tests have been changed
- [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

### Checklist:
- [x] I have reviewed my code
- [x] The code will run locally
- [x] My code has no unused/commented out code
- [ ] I have commented my code, particularly in hard-to-understand areas

(Optional) What questions do you have? Anything specific you want feedback on?

- Is using a Proc when dealing with the json-api serializer gem the best way to conditionally render an attribute? 

(For Fun!) Please include a link to a gif [or add an emoji] of your feelings about this branch.
![peter](https://github.com/user-attachments/assets/2621c915-743b-4734-8f82-c2f320599fe4)
